### PR TITLE
Make this library available via Bower.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,12 @@
+{
+  "name": "scoreunder",
+  "version": "1.3.0",
+  "main": "scoreunder.js",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
Added a bower.json so it scoreunder can be installed via Bower.

It would be immensely helpful if this library could be installed via Bower. This is a start to that. While this library doesn't yet have Node or Bower modules, it may in the future so I left those ignores in there.

After (if you do) merging this, run this command: `bower register scoreunder git@github.com:loop-recur/scoreunder.git`

This will make this package available via Bower. Also make sure my version I grabbed is correct. I wasn't sure exactly what it was.
