### PR TITLE
Make isEqual autocurry

### DIFF
--- a/scoreunder.js
+++ b/scoreunder.js
@@ -1550,7 +1550,7 @@
      * });
      * // => true
      */
-    function isEqual(a, b, callback, thisArg, stackA, stackB) {
+    var isEqual = function(a, b, callback, thisArg, stackA, stackB) {
       // used to indicate that when comparing objects, `a` has at least the properties of `b`
       var whereIndicator = callback === indicatorObject;
       if (typeof callback == 'function' && !whereIndicator) {
@@ -1706,7 +1706,7 @@
         releaseArray(stackB);
       }
       return result;
-    }
+    }.autoCurry(2)
 
     /**
      * Checks if `value` is, or can be coerced to, a finite number.

--- a/test/spec/scoreunder_spec.js
+++ b/test/spec/scoreunder_spec.js
@@ -123,6 +123,7 @@ describe("Scoreunder", function() {
       var isEven = function(n) { return !(n % 2); }
       expect(_.filter(isEven, list)).toEqual([2,4]);
       expect(_.filter(isEven)(list)).toEqual([2,4]);
+      expect(_.filter(_.isEqual)(1)).toEqual([1]);
     });
   });
 


### PR DESCRIPTION
Quite simple, make something like this possible:

```
_.isEqual(1)(1)
_.filter(_.isEqual(1), [1,2,3])
```
